### PR TITLE
[build] Fix linking issues with Clang under Linux

### DIFF
--- a/libavformat/premake5.lua
+++ b/libavformat/premake5.lua
@@ -15,6 +15,7 @@ project("libavformat")
 
   links({
     "libavutil",
+    "libavcodec",
   })
 
   -- libavformat/Makefile:


### PR DESCRIPTION
This is required to make FFmpeg compile while using Clang on Linux. Without this change compile will fail during linking claiming missing links coming from libavcodec library.